### PR TITLE
Add Related Wallpapers section to wallpaper pages

### DIFF
--- a/app/bingwallpapers/[id]/page.tsx
+++ b/app/bingwallpapers/[id]/page.tsx
@@ -3,7 +3,8 @@ import { notFound, redirect } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
 import Script from "next/script";
-import { getWallpaper } from "@/libs/Client";
+import { getWallpaper, getRelatedWallpapers } from "@/libs/Client";
+import RelatedWallpapers from "@/components/RelatedWallpapers";
 import { colorsToDataURL } from "@/libs/image";
 import { intToDate } from "@/libs/date";
 import type { Metadata } from "next";
@@ -52,6 +53,8 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
   if (!isNaN(Number(params.id))) {
     redirect(`/bingwallpapers/${id}`);
   }
+
+  const relatedWallpapers = await getRelatedWallpapers(id, tags);
 
   const t = Object.entries(tags).sort((a, b) => b[1] - a[1]);
   const tagFields = t.map((l, i) => (
@@ -111,6 +114,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
         {copyright} - {intToDate(date)}
       </p>
       <p className="mt-2 content-margin">{tagFields}</p>
+      <RelatedWallpapers wallpapers={relatedWallpapers} />
     </>
   );
 }

--- a/app/bingwallpapers/[id]/page.tsx
+++ b/app/bingwallpapers/[id]/page.tsx
@@ -1,10 +1,9 @@
-import { Fragment } from "react";
 import { notFound, redirect } from "next/navigation";
 import Image from "next/image";
-import Link from "next/link";
 import Script from "next/script";
 import { getWallpaper, getRelatedWallpapers } from "@/libs/Client";
 import RelatedWallpapers from "@/components/RelatedWallpapers";
+import TagList from "@/components/TagList";
 import { colorsToDataURL } from "@/libs/image";
 import { intToDate } from "@/libs/date";
 import type { Metadata } from "next";
@@ -56,18 +55,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
 
   const relatedWallpapers = await getRelatedWallpapers(id, tags);
 
-  const t = Object.entries(tags).sort((a, b) => b[1] - a[1]);
-  const tagFields = t.map((l, i) => (
-    <Fragment key={i}>
-      <Link
-        prefetch={false}
-        href={`/bingwallpapers/tags/${l[0]}`}
-        className="leading-10 whitespace-nowrap px-3 py-2 rounded-md bg-slate-800 text-gray-300 hover:bg-slate-700 hover:text-white"
-      >
-        {l[0]}
-      </Link>{" "}
-    </Fragment>
-  ));
+  const sortedTags = Object.entries(tags).sort((a, b) => b[1] - a[1]);
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -113,7 +101,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
       <p className="text-gray-400 content-margin">
         {copyright} - {intToDate(date)}
       </p>
-      <p className="mt-2 content-margin">{tagFields}</p>
+      <TagList tags={sortedTags} />
       <RelatedWallpapers wallpapers={relatedWallpapers} />
     </>
   );

--- a/components/RelatedWallpapers.tsx
+++ b/components/RelatedWallpapers.tsx
@@ -1,0 +1,19 @@
+import WallpaperList from "@/components/WallpaperList";
+import { Wallpaper } from "@/libs/Client";
+
+export default function RelatedWallpapers({
+  wallpapers,
+}: {
+  wallpapers: Wallpaper[];
+}) {
+  if (wallpapers.length === 0) return null;
+
+  return (
+    <section className="mt-8">
+      <h2 className="text-xl text-white mb-4 content-margin md:text-2xl">
+        Related Wallpapers
+      </h2>
+      <WallpaperList wallpapers={wallpapers} />
+    </section>
+  );
+}

--- a/components/TagList.tsx
+++ b/components/TagList.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import Link from "next/link";
+
+export default function TagList({ tags }: { tags: [string, number][] }) {
+  const [expanded, setExpanded] = useState(false);
+  const [hasOverflow, setHasOverflow] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const checkOverflow = () => {
+      if (containerRef.current) {
+        setHasOverflow(
+          containerRef.current.scrollHeight > containerRef.current.clientHeight
+        );
+      }
+    };
+
+    checkOverflow();
+    window.addEventListener("resize", checkOverflow);
+    return () => window.removeEventListener("resize", checkOverflow);
+  }, [tags]);
+
+  return (
+    <div className="mt-2 content-margin">
+      <div
+        ref={containerRef}
+        className={`flex flex-wrap gap-2 overflow-hidden transition-[max-height] duration-300 ${
+          expanded ? "max-h-[500px]" : "max-h-[88px]"
+        }`}
+      >
+        {tags.map(([tag]) => (
+          <Link
+            key={tag}
+            prefetch={false}
+            href={`/bingwallpapers/tags/${tag}`}
+            className="whitespace-nowrap px-3 py-2 rounded-md bg-slate-800 text-gray-300 hover:bg-slate-700 hover:text-white"
+          >
+            {tag}
+          </Link>
+        ))}
+      </div>
+      {(hasOverflow || expanded) && (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="mt-2 text-gray-400 hover:text-white"
+        >
+          {expanded ? "Show less" : "More"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/libs/Client.ts
+++ b/libs/Client.ts
@@ -108,3 +108,20 @@ export async function getWallpaper(id: string) {
     wallpaper: json as Wallpaper,
   };
 }
+
+export async function getRelatedWallpapers(
+  currentId: string,
+  tags: Record<string, number>,
+  limit: number = 6
+): Promise<Wallpaper[]> {
+  const sortedTags = Object.entries(tags).sort((a, b) => b[1] - a[1]);
+  if (sortedTags.length === 0) return [];
+
+  const topTag = sortedTags[0][0];
+  try {
+    const data = await getWallpapersByTag(topTag);
+    return data.wallpapers.filter((w) => w.id !== currentId).slice(0, limit);
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a "Related Wallpapers" section to individual wallpaper pages
- Shows up to 6 wallpapers that share the same top tag (highest frequency) as the current wallpaper
- Reuses existing `WallpaperList` component and `getWallpapersByTag` API

## Test plan
- [ ] Navigate to any wallpaper page and verify "Related Wallpapers" section appears below tags
- [ ] Verify related wallpapers share the same top tag as the current wallpaper
- [ ] Verify current wallpaper is not shown in related section
- [ ] Test a wallpaper with no tags to verify section is hidden
- [ ] Run `npm run build` to verify no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)